### PR TITLE
added function to get just the real component from the CKKSPlaintext

### DIFF
--- a/src/include/docstrings/plaintext_docs.h
+++ b/src/include/docstrings/plaintext_docs.h
@@ -103,4 +103,13 @@ const char* ptx_GetCKKSPackedValue_docs = R"pbdoc(
 )pbdoc";
 
 
+//GetRealPackedValue
+const char* ptx_GetRealPackedValue_docs = R"pbdoc(
+    Get the real component of the packed value of the plaintext for CKKS-based plaintexts.
+
+    :return: The real-component of the packed value of the plaintext.
+    :rtype: List[float]
+)pbdoc";
+
+
 #endif // PLAINTEXT_DOCSTRINGS_H

--- a/src/lib/bindings.cpp
+++ b/src/lib/bindings.cpp
@@ -895,6 +895,9 @@ void bind_encodings(py::module &m)
             ptx_Decode_docs)
         .def("GetCKKSPackedValue", &PlaintextImpl::GetCKKSPackedValue,
             ptx_GetCKKSPackedValue_docs)
+
+        .def("GetRealPackedValue", &PlaintextImpl::GetRealPackedValue,
+            ptx_GetRealPackedValue_docs)
         .def("__repr__", [](const PlaintextImpl &p)
              {
         std::stringstream ss;


### PR DESCRIPTION
Simple code to get back the values as a real vector instead of a complex vector that needs to be converted on the users end