### PR TITLE
Add support for PyPI packaging. Fixes #59

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ build/
 .settings/
 docs/
 demoData/
+dist/
+openfhe/openfhe.so
+openfhe.egg-info/

--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,7 @@ docs/
 demoData/
 dist/
 openfhe/openfhe.so
+openfhe/*.pyi
 openfhe.egg-info/
+stubs/
+.venv/

--- a/build_package.sh
+++ b/build_package.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Exit on any error
+set -e
+
+# Find the venv directory
+if [ -d ".venv" ]; then
+    VENV_DIR=".venv"
+elif [ -d "../.venv" ]; then
+    VENV_DIR="../.venv"
+else
+    echo "The virtual environment does not exist. Please run 'python -m venv .venv' to create it." >&2
+    exit 1
+fi
+
+# Activate the virtual environment
+source $VENV_DIR/bin/activate
+
+# Install pybind11-stubgen
+if ! pip show pybind11-stubgen > /dev/null; then
+    pip install pybind11-stubgen
+fi
+
+# Check if the virtual environment has the openfhe package installed
+if ! pip show openfhe > /dev/null; then
+    echo "The openfhe package is not installed in the virtual environment. Please run 'pip install -e .' to install it." >&2
+    exit 1
+fi
+
+# Generate stub files using pybind11-stubgen
+echo "Generating stub files..."
+pybind11-stubgen openfhe
+
+# Check if stub generation was successful
+if [ $? -eq 0 ]; then
+    echo "Stub files generated successfully."
+else
+    echo "Stub generation failed." >&2
+    exit 1
+fi
+
+# Move the generated stub files to the openfhe package directory
+echo "Moving the generated stub files to the openfhe package directory..."
+mv stubs/openfhe/* openfhe/
+rm -r -d stubs
+
+# Build the source distribution and wheel distribution
+echo "Building the sdist and bdist_wheel..."
+python setup.py sdist bdist_wheel
+
+# Indicate where the distributions were saved
+echo "The distributions have been built and are located in the 'dist' directory. You can install the package using 'pip install dist/<distribution_file>'."

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -17,6 +17,7 @@ Pygments==2.11.2
 pyparsing==3.0.7
 pytz==2021.3
 requests==2.27.1
+setuptools==69.0.3
 snowballstemmer==2.2.0
 Sphinx==4.4.0
 sphinx-rtd-theme==1.0.0

--- a/openfhe/__init__.py
+++ b/openfhe/__init__.py
@@ -1,0 +1,1 @@
+from .openfhe import *

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
         'build_ext': CMakeBuild,
         'sdist': SDist
     },
-    zip_safe=False,
     include_package_data=True,
     python_requires=">=3.6",
+    install_requires=['pybind11', 'pybind11-global']
 )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,78 @@
+import os
+import subprocess
+import sys
+from setuptools import setup, Extension
+from setuptools.command.sdist import sdist as _sdist
+from setuptools.command.build_ext import build_ext as _build_ext
+from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
+import glob
+import shutil
+
+__version__ = '0.8.4'
+
+class CMakeExtension(Extension):
+    def __init__(self, name, sourcedir=''):
+        super().__init__(name, sources=[])
+        self.sourcedir = os.path.abspath(sourcedir)
+
+class CMakeBuild(_build_ext):
+
+    def run(self):
+        for ext in self.extensions:
+            self.build_cmake(ext)
+
+    def build_cmake(self, ext):
+        if os.path.exists('openfhe/openfhe.so'):
+            return
+        extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
+        print(extdir)
+        cmake_args = ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
+                      '-DPYTHON_EXECUTABLE=' + sys.executable]
+
+        cfg = 'Debug' if self.debug else 'Release'
+        build_args = ['--config', cfg]
+
+        build_temp = os.path.abspath(self.build_temp)
+        os.makedirs(build_temp, exist_ok=True)
+
+        num_cores = os.cpu_count() or 1
+        build_args += ['--parallel', str(num_cores)]
+
+        subprocess.check_call(['cmake', ext.sourcedir] + cmake_args, cwd=build_temp)
+        subprocess.check_call(['cmake', '--build', '.', '--target', ext.name] + build_args, cwd=build_temp)
+
+        so_files = glob.glob(os.path.join(extdir, '*.so'))
+        if not so_files:
+            raise RuntimeError("Cannot find any built .so file in " + extdir)
+
+        src_file = so_files[0] 
+        dst_file = os.path.join('openfhe', 'openfhe.so')
+        shutil.move(src_file, dst_file)
+
+# Run build_ext before sdist
+class SDist(_sdist):
+    def run(self):
+        if os.path.exists('openfhe/openfhe.so'):
+            os.remove('openfhe/openfhe.so')
+        self.run_command('build_ext')
+        super().run()
+
+setup(
+    name='openfhe',
+    version=__version__,
+    description='Python wrapper for OpenFHE C++ library.',
+    author='OpenFHE Team',
+    author_email='contact@openfhe.org',
+    url='https://github.com/openfheorg/openfhe-python',
+    license='BSD-2-Clause',
+    packages=['openfhe'],
+    package_data={'openfhe': ['*.so']},
+    ext_modules=[CMakeExtension('openfhe', sourcedir='')],
+    cmdclass={
+        'build_ext': CMakeBuild,
+        'sdist': SDist
+    },
+    zip_safe=False,
+    include_package_data=True,
+    python_requires=">=3.6",
+)

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     url='https://github.com/openfheorg/openfhe-python',
     license='BSD-2-Clause',
     packages=['openfhe'],
-    package_data={'openfhe': ['*.so']},
+    package_data={'openfhe': ['*.so', '*.pyi']},
     ext_modules=[CMakeExtension('openfhe', sourcedir='')],
     cmdclass={
         'build_ext': CMakeBuild,
@@ -74,5 +74,5 @@ setup(
     },
     include_package_data=True,
     python_requires=">=3.6",
-    install_requires=['pybind11', 'pybind11-global']
+    install_requires=['pybind11', 'pybind11-global', 'pybind11-stubgen']
 )


### PR DESCRIPTION
Hello!

This PR adds support for PyPI packaging when using the command `python setup.py sdist bdist_wheel`. 
The purpose is to make easier for developers to create a package of their own and for the openfhe org to be able to publish packages easily.

I have created a setup.py that compiles the library with CMake and then creates the sdist `tar.gz` and bdist_wheel `whl` packages with the library inside, allowing for easy installation with `pip install` and integration with `import openfhe`.

There are some caveats to the approach I followed. Since `build_ext` executes at the end of the setup process, it was creating empty packages and then compiling the library. To work around that I created a custom `sdist` class that forces a `build_ext` _before_ all the other commands.
That introduces the problem of **double compilation**, which is done in the `bdist_wheel` phase. To prevent that, I created the (admittedly not very elegant) solution of passing the compilation if the .so file already exists. That's also why it gets removed during the `sdist` phase of the build.
There also isn't any docstring for now, which complicated knowing which functions are available and what they do, forcing you to rely on the documentation.

If you have any feedback or a better approach to the code, please let me know!

Thank you.