### PR TITLE
Adolgert limit pytest path

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,10 @@ conda develop lib
 which creates a lib folder, moves the built `.so` file into that lib folder, and tells conda where to look for external libraries.
 
 **Note** You may wish to copy the `.so` file to any projects of your own, or add it to your system path to source from.
+
 ## Running Tests
 
-Run tests with [pytest](https://docs.pytest.org). See the [testing readme](tests/README.md) for more information.
+Run tests with [pytest](https://docs.pytest.org), which may be called `pytest-3` on your system. See the [testing readme](tests/README.md) for more information.
 
 ```bash
 pytest [--run-long]

--- a/README.md
+++ b/README.md
@@ -90,6 +90,13 @@ conda develop lib
 which creates a lib folder, moves the built `.so` file into that lib folder, and tells conda where to look for external libraries.
 
 **Note** You may wish to copy the `.so` file to any projects of your own, or add it to your system path to source from.
+## Running Tests
+
+Run tests with [pytest](https://docs.pytest.org). See the [testing readme](tests/README.md) for more information.
+
+```bash
+pytest [--run-long]
+```
 
 ## Code Examples
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths =
+    tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -35,7 +35,7 @@ Test all functions matching a name. For instance, this would pick up
 pytest -k add
 ```
 
-As a reminder, pytest can be helpful for debugging. This command-lin option
+As a reminder, pytest can be helpful for debugging. This command-line option
 shows debug output from logging statements.
 
 ```bash

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,10 +1,10 @@
 # Working with Tests
 
-These tests use Pytest (https://docs.pytest.org/).
+These tests use [Pytest](https://docs.pytest.org/).
 
 ## Running and Using Tests
 
-These tests assume that openfhe-python is installed in the current python environment, which you can check by running
+These tests assume that openfhe-python is installed in the current python environment, which you can check by importing openfhe.
 ```bash
 python -c "__import__('openfhe')"
 ```
@@ -22,7 +22,7 @@ pytest --run-all
 
 ### General Pytest usage
 
-Test a particular file:
+This is a quick reminder of pytest's features. To test a particular file:
 
 ```bash
 pytest test_particular_file.py
@@ -35,7 +35,8 @@ Test all functions matching a name. For instance, this would pick up
 pytest -k add
 ```
 
-As a reminder, pytest can be helpful for debugging.
+As a reminder, pytest can be helpful for debugging. This command-lin option
+shows debug output from logging statements.
 
 ```bash
 pytest --log-cli-level=debug
@@ -64,7 +65,7 @@ The goal is for the Github Actions tests to reassure a committer that they have
 not broken the Python wrapper.
 
 **Import OpenFHE as fhe** -- Unit tests tend to use more imports than most
-code, for instance JSON, which conflicts with an OpenFHE name, so quality
+code, for instance JSON, which conflicts with an OpenFHE name, so qualify
 imports in the tests.
 
 ```python


### PR DESCRIPTION
The important change here is the addition of a file called `pytest.ini` which tells pytest to look in the tests directory and ignore other files that may begin with "test*". This fixes a problem where running pytest in the root directory failed because an example in the main source code, not a unit test, would run and fail.

This was reviewed by two people and is re-uploaded as a branch on the main repo. I may be able to merge it but would be more comfortable if somebody else hit the button.

Thank You!