### PR TITLE
library __init__ uses a relative path which makes pip install fail

### DIFF
--- a/openfhe/__init__.py
+++ b/openfhe/__init__.py
@@ -1,1 +1,1 @@
-from .openfhe import *
+from openfhe.openfhe import *


### PR DESCRIPTION
Hi!

This is for Issue #38: https://github.com/openfheorg/openfhe-python/issues/138.

 * PEP8 [recommends absolute imports](https://peps.python.org/pep-0008/#imports) but says relative usually work. This case, importing a local .so file, is where they can fail.
 * Examples [Keras](https://github.com/keras-team/keras/blob/master/keras/__init__.py#L10) and (PyTorch)[https://github.com/pytorch/pytorch/blob/main/torch/__init__.py#L1582].
 
HTH,
Drew