### PR TITLE
#145 Add Serialize/Deserialize functions

### DIFF
--- a/src/include/pke/serialization.h
+++ b/src/include/pke/serialization.h
@@ -33,6 +33,7 @@
 #include "bindings.h"
 
 using namespace lbcrypto;
+namespace py = pybind11;
 
 template <typename ST>
 bool SerializeEvalMultKeyWrapper(const std::string& filename, const ST& sertype, std::string id);
@@ -42,5 +43,17 @@ bool SerializeEvalAutomorphismKeyWrapper(const std::string& filename, const ST& 
 
 template <typename ST>
 bool DeserializeEvalMultKeyWrapper(const std::string& filename, const ST& sertype);
+
+template <typename T, typename ST>
+std::string SerializeToStringWrapper(const T& obj, const ST& sertype);
+
+template <typename T, typename ST>
+py::bytes SerializeToBytesWrapper(const T& obj, const ST& sertype);
+
+template <typename T, typename ST>
+T DeserializeFromStringWrapper(const std::string& str, const ST& sertype);
+
+template <typename T, typename ST>
+T DeserializeFromBytesWrapper(const py::bytes& bytes, const ST& sertype);
 
 #endif // OPENFHE_SERIALIZATION_BINDINGS_H

--- a/src/lib/pke/serialization.cpp
+++ b/src/lib/pke/serialization.cpp
@@ -147,23 +147,23 @@ void bind_serialization(pybind11::module &m) {
     // JSON Serialization to string
     m.def("Serialize", &SerializeToStringWrapper<CryptoContext<DCRTPoly>, SerType::SERJSON>,
           py::arg("obj"), py::arg("sertype"));
-    m.def("Deserialize", &DeserializeFromStringWrapper<CryptoContext<DCRTPoly>, SerType::SERJSON>,
+    m.def("DeserializeCryptoContextString", &DeserializeFromStringWrapper<CryptoContext<DCRTPoly>, SerType::SERJSON>,
           py::arg("str"), py::arg("sertype"));
     m.def("Serialize", &SerializeToStringWrapper<PublicKey<DCRTPoly>, SerType::SERJSON>,
           py::arg("obj"), py::arg("sertype"));
-    m.def("Deserialize", &DeserializeFromStringWrapper<PublicKey<DCRTPoly>, SerType::SERJSON>,
+    m.def("DeserializePublicKeyString", &DeserializeFromStringWrapper<PublicKey<DCRTPoly>, SerType::SERJSON>,
           py::arg("str"), py::arg("sertype"));
     m.def("Serialize", &SerializeToStringWrapper<PrivateKey<DCRTPoly>, SerType::SERJSON>,
           py::arg("obj"), py::arg("sertype"));
-    m.def("Deserialize", &DeserializeFromStringWrapper<PrivateKey<DCRTPoly>, SerType::SERJSON>,
+    m.def("DeserializePrivateKeyString", &DeserializeFromStringWrapper<PrivateKey<DCRTPoly>, SerType::SERJSON>,
           py::arg("str"), py::arg("sertype"));
     m.def("Serialize", &SerializeToStringWrapper<Ciphertext<DCRTPoly>, SerType::SERJSON>,
           py::arg("obj"), py::arg("sertype"));
-    m.def("Deserialize", &DeserializeFromStringWrapper<Ciphertext<DCRTPoly>, SerType::SERJSON>,
+    m.def("DeserializeCiphertextString", &DeserializeFromStringWrapper<Ciphertext<DCRTPoly>, SerType::SERJSON>,
           py::arg("str"), py::arg("sertype"));
     m.def("Serialize", &SerializeToStringWrapper<EvalKey<DCRTPoly>, SerType::SERJSON>,
           py::arg("obj"), py::arg("sertype"));
-    m.def("Deserialize", &DeserializeFromStringWrapper<EvalKey<DCRTPoly>, SerType::SERJSON>,
+    m.def("DeserializeEvalKeyString", &DeserializeFromStringWrapper<EvalKey<DCRTPoly>, SerType::SERJSON>,
           py::arg("str"), py::arg("sertype"));
 
     // Binary Serialization
@@ -191,23 +191,23 @@ void bind_serialization(pybind11::module &m) {
     // Binary Serialization to bytes
     m.def("Serialize", &SerializeToBytesWrapper<CryptoContext<DCRTPoly>, SerType::SERBINARY>,
           py::arg("obj"), py::arg("sertype"));
-    m.def("Deserialize", &DeserializeFromBytesWrapper<CryptoContext<DCRTPoly>, SerType::SERBINARY>,
+    m.def("DeserializeCryptoContextString", &DeserializeFromBytesWrapper<CryptoContext<DCRTPoly>, SerType::SERBINARY>,
           py::arg("str"), py::arg("sertype"));
     m.def("Serialize", &SerializeToBytesWrapper<PublicKey<DCRTPoly>, SerType::SERBINARY>,
           py::arg("obj"), py::arg("sertype"));
-    m.def("Deserialize", &DeserializeFromBytesWrapper<PublicKey<DCRTPoly>, SerType::SERBINARY>,
+    m.def("DeserializePublicKeyString", &DeserializeFromBytesWrapper<PublicKey<DCRTPoly>, SerType::SERBINARY>,
           py::arg("str"), py::arg("sertype"));
     m.def("Serialize", &SerializeToBytesWrapper<PrivateKey<DCRTPoly>, SerType::SERBINARY>,
           py::arg("obj"), py::arg("sertype"));
-    m.def("Deserialize", &DeserializeFromBytesWrapper<PrivateKey<DCRTPoly>, SerType::SERBINARY>,
+    m.def("DeserializePrivateKeyString", &DeserializeFromBytesWrapper<PrivateKey<DCRTPoly>, SerType::SERBINARY>,
           py::arg("str"), py::arg("sertype"));
     m.def("Serialize", &SerializeToBytesWrapper<Ciphertext<DCRTPoly>, SerType::SERBINARY>,
           py::arg("obj"), py::arg("sertype"));
-    m.def("Deserialize", &DeserializeFromBytesWrapper<Ciphertext<DCRTPoly>, SerType::SERBINARY>,
+    m.def("DeserializeCiphertextString", &DeserializeFromBytesWrapper<Ciphertext<DCRTPoly>, SerType::SERBINARY>,
           py::arg("str"), py::arg("sertype"));
     m.def("Serialize", &SerializeToBytesWrapper<EvalKey<DCRTPoly>, SerType::SERBINARY>,
           py::arg("obj"), py::arg("sertype"));
-    m.def("Deserialize", &DeserializeFromBytesWrapper<EvalKey<DCRTPoly>, SerType::SERBINARY>,
+    m.def("DeserializeEvalKeyString", &DeserializeFromBytesWrapper<EvalKey<DCRTPoly>, SerType::SERBINARY>,
           py::arg("str"), py::arg("sertype"));
 }
 

--- a/src/lib/pke/serialization.cpp
+++ b/src/lib/pke/serialization.cpp
@@ -88,6 +88,39 @@ std::tuple<CryptoContext<DCRTPoly>, bool> DeserializeCCWrapper(const std::string
     return std::make_tuple(newob, result);
 }
 
+template <typename T, typename ST>
+std::string SerializeToStringWrapper(const T& obj, const ST& sertype) {
+    std::ostringstream oss;
+    Serial::Serialize<T>(obj, oss, sertype);
+    return oss.str();
+}
+
+template <typename T, typename ST>
+py::bytes SerializeToBytesWrapper(const T& obj, const ST& sertype) {
+    std::ostringstream oss(std::ios::binary);
+    Serial::Serialize<T>(obj, oss, sertype);
+    std::string str = oss.str();
+    return py::bytes(str);
+}
+
+template <typename T, typename ST>
+T DeserializeFromStringWrapper(const std::string& str, const ST& sertype) {
+    T obj;
+    std::istringstream iss(str);
+    Serial::Deserialize<T>(obj, iss, sertype);
+    return obj;
+}
+
+template <typename T, typename ST>
+T DeserializeFromBytesWrapper(const py::bytes& bytes, const ST& sertype) {
+    T obj;
+    std::string str(bytes);
+    std::istringstream iss(str, std::ios::binary);
+    Serial::Deserialize<T>(obj, iss, sertype);
+    return obj;
+}
+
+
 void bind_serialization(pybind11::module &m) {
     // Json Serialization
     m.def("SerializeToFile", static_cast<bool (*)(const std::string &, const CryptoContext<DCRTPoly> &, const SerType::SERJSON &)>(&Serial::SerializeToFile<DCRTPoly>),
@@ -110,6 +143,29 @@ void bind_serialization(pybind11::module &m) {
           py::arg("filename"), py::arg("obj"), py::arg("sertype"));
     m.def("DeserializeEvalKey", static_cast<std::tuple<EvalKey<DCRTPoly>,bool> (*)(const std::string&, const SerType::SERJSON&)>(&DeserializeFromFileWrapper<EvalKey<DCRTPoly>, SerType::SERJSON>),
           py::arg("filename"), py::arg("sertype"));
+
+    // JSON Serialization to string
+    m.def("Serialize", &SerializeToStringWrapper<CryptoContext<DCRTPoly>, SerType::SERJSON>,
+          py::arg("obj"), py::arg("sertype"));
+    m.def("Deserialize", &DeserializeFromStringWrapper<CryptoContext<DCRTPoly>, SerType::SERJSON>,
+          py::arg("str"), py::arg("sertype"));
+    m.def("Serialize", &SerializeToStringWrapper<PublicKey<DCRTPoly>, SerType::SERJSON>,
+          py::arg("obj"), py::arg("sertype"));
+    m.def("Deserialize", &DeserializeFromStringWrapper<PublicKey<DCRTPoly>, SerType::SERJSON>,
+          py::arg("str"), py::arg("sertype"));
+    m.def("Serialize", &SerializeToStringWrapper<PrivateKey<DCRTPoly>, SerType::SERJSON>,
+          py::arg("obj"), py::arg("sertype"));
+    m.def("Deserialize", &DeserializeFromStringWrapper<PrivateKey<DCRTPoly>, SerType::SERJSON>,
+          py::arg("str"), py::arg("sertype"));
+    m.def("Serialize", &SerializeToStringWrapper<Ciphertext<DCRTPoly>, SerType::SERJSON>,
+          py::arg("obj"), py::arg("sertype"));
+    m.def("Deserialize", &DeserializeFromStringWrapper<Ciphertext<DCRTPoly>, SerType::SERJSON>,
+          py::arg("str"), py::arg("sertype"));
+    m.def("Serialize", &SerializeToStringWrapper<EvalKey<DCRTPoly>, SerType::SERJSON>,
+          py::arg("obj"), py::arg("sertype"));
+    m.def("Deserialize", &DeserializeFromStringWrapper<EvalKey<DCRTPoly>, SerType::SERJSON>,
+          py::arg("str"), py::arg("sertype"));
+
     // Binary Serialization
     m.def("SerializeToFile", static_cast<bool (*)(const std::string&,const CryptoContext<DCRTPoly>&, const SerType::SERBINARY&)>(&Serial::SerializeToFile<DCRTPoly>),
           py::arg("filename"), py::arg("obj"), py::arg("sertype"));
@@ -130,7 +186,28 @@ void bind_serialization(pybind11::module &m) {
     m.def("SerializeToFile", static_cast<bool (*)(const std::string&, const EvalKey<DCRTPoly>&, const SerType::SERBINARY&)>(&Serial::SerializeToFile<EvalKey<DCRTPoly>>),
           py::arg("filename"), py::arg("obj"), py::arg("sertype"));
     m.def("DeserializeEvalKey", static_cast<std::tuple<EvalKey<DCRTPoly>,bool> (*)(const std::string&, const SerType::SERBINARY&)>(&DeserializeFromFileWrapper<EvalKey<DCRTPoly>, SerType::SERBINARY>),
-            py::arg("filename"), py::arg("sertype"));  
-    
+          py::arg("filename"), py::arg("sertype"));
+
+    // Binary Serialization to bytes
+    m.def("Serialize", &SerializeToBytesWrapper<CryptoContext<DCRTPoly>, SerType::SERBINARY>,
+          py::arg("obj"), py::arg("sertype"));
+    m.def("Deserialize", &DeserializeFromBytesWrapper<CryptoContext<DCRTPoly>, SerType::SERBINARY>,
+          py::arg("str"), py::arg("sertype"));
+    m.def("Serialize", &SerializeToBytesWrapper<PublicKey<DCRTPoly>, SerType::SERBINARY>,
+          py::arg("obj"), py::arg("sertype"));
+    m.def("Deserialize", &DeserializeFromBytesWrapper<PublicKey<DCRTPoly>, SerType::SERBINARY>,
+          py::arg("str"), py::arg("sertype"));
+    m.def("Serialize", &SerializeToBytesWrapper<PrivateKey<DCRTPoly>, SerType::SERBINARY>,
+          py::arg("obj"), py::arg("sertype"));
+    m.def("Deserialize", &DeserializeFromBytesWrapper<PrivateKey<DCRTPoly>, SerType::SERBINARY>,
+          py::arg("str"), py::arg("sertype"));
+    m.def("Serialize", &SerializeToBytesWrapper<Ciphertext<DCRTPoly>, SerType::SERBINARY>,
+          py::arg("obj"), py::arg("sertype"));
+    m.def("Deserialize", &DeserializeFromBytesWrapper<Ciphertext<DCRTPoly>, SerType::SERBINARY>,
+          py::arg("str"), py::arg("sertype"));
+    m.def("Serialize", &SerializeToBytesWrapper<EvalKey<DCRTPoly>, SerType::SERBINARY>,
+          py::arg("obj"), py::arg("sertype"));
+    m.def("Deserialize", &DeserializeFromBytesWrapper<EvalKey<DCRTPoly>, SerType::SERBINARY>,
+          py::arg("str"), py::arg("sertype"));
 }
 

--- a/tests/test_serial_cc.py
+++ b/tests/test_serial_cc.py
@@ -48,16 +48,26 @@ def test_serial_cryptocontext_str(mode):
 
     cryptoContext = fhe.GenCryptoContext(parameters)
     cryptoContext.Enable(fhe.PKESchemeFeature.PKE)
+    cryptoContext.Enable(fhe.PKESchemeFeature.PRE)
 
     keypair = cryptoContext.KeyGen()
     vectorOfInts = list(range(12))
     plaintext = cryptoContext.MakePackedPlaintext(vectorOfInts)
     ciphertext = cryptoContext.Encrypt(keypair.publicKey, plaintext)
+    evalKey = cryptoContext.ReKeyGen(keypair.secretKey, keypair.publicKey)
+
 
     cryptoContext_ser = fhe.Serialize(cryptoContext, mode)
     LOGGER.debug("The cryptocontext has been serialized.")
+    publickey_ser = fhe.Serialize(keypair.publicKey, mode)
+    LOGGER.debug("The public key has been serialized.")
+    secretkey_ser = fhe.Serialize(keypair.secretKey, mode)
+    LOGGER.debug("The private key has been serialized.")
     ciphertext_ser = fhe.Serialize(ciphertext, mode)
     LOGGER.debug("The ciphertext has been serialized.")
+    evalKey_ser = fhe.Serialize(evalKey, mode)
+    LOGGER.debug("The evaluation key has been serialized.")
+
 
     cryptoContext.ClearEvalMultKeys()
     cryptoContext.ClearEvalAutomorphismKeys()
@@ -67,6 +77,18 @@ def test_serial_cryptocontext_str(mode):
     assert isinstance(cc, fhe.CryptoContext)
     LOGGER.debug("The cryptocontext has been deserialized.")
 
+    pk = fhe.DeserializePublicKeyString(publickey_ser, mode)
+    assert isinstance(pk, fhe.PublicKey)
+    LOGGER.debug("The public key has been deserialized.")
+
+    sk = fhe.DeserializePrivateKeyString(secretkey_ser, mode)
+    assert isinstance(sk, fhe.PrivateKey)
+    LOGGER.debug("The private key has been deserialized.")
+
     ct = fhe.DeserializeCiphertextString(ciphertext_ser, mode)
     assert isinstance(ct, fhe.Ciphertext)
     LOGGER.debug("The ciphertext has been reserialized.")
+
+    ek = fhe.DeserializeEvalKeyString(evalKey_ser, mode)
+    assert isinstance(ek, fhe.EvalKey)
+    LOGGER.debug("The evaluation key has been deserialized.")


### PR DESCRIPTION
Follow up to the #151 PR.

Original issue:

> Closes #145
> 
> Adds `openfhe.Serialize()` and deserialization for every object so it can do it directly into a variable rather than writing a file that has to be read afterwards.
> I've tested both and they're working well.
> 
> I'd have liked to use other names rather than `...String` for the deserialization part. It would have made more sense to change the other function names to something like `...ToFile` but since that would break a lot of existing code I'll keep it like this, unless there is a suggestion for a better name.
> 
> If you see any issue with the code or you believe it makes more sense in another file, please let me know.