### PR TITLE
Add bindings for GetNoiseScaleDeg/SetNoiseScaleDeg

### DIFF
--- a/src/lib/bindings.cpp
+++ b/src/lib/bindings.cpp
@@ -1113,7 +1113,9 @@ void bind_ciphertext(py::module &m)
     // .def("GetScalingFactor", &CiphertextImpl<DCRTPoly>::GetScalingFactor)
     // .def("SetScalingFactor", &CiphertextImpl<DCRTPoly>::SetScalingFactor)
      .def("GetSlots", &CiphertextImpl<DCRTPoly>::GetSlots)
-     .def("SetSlots", &CiphertextImpl<DCRTPoly>::SetSlots);
+     .def("SetSlots", &CiphertextImpl<DCRTPoly>::SetSlots)
+     .def("GetNoiseScaleDeg", &CiphertextImpl<DCRTPoly>::GetNoiseScaleDeg)
+     .def("SetNoiseScaleDeg", &CiphertextImpl<DCRTPoly>::SetNoiseScaleDeg);
 }
 
 void bind_schemes(py::module &m){


### PR DESCRIPTION
This PR adds bindings to GetNoiseScaleDeg and SetNoiseScaleDeg to the python bindings for Ciphertext.

If this is not the proper way for me as an external user to contribute changes, please let me know what to do instead!