### PR TITLE
Fix:  UndefinedVar: Usage of undefined variable '$LD_LIBRARY_PATH' (line 36)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,6 +33,7 @@ RUN git clone https://github.com/openfheorg/openfhe-development.git \
 
 # Assume that OpenFHE installs libraries into /usr/local/lib
 # Update LD_LIBRARY_PATH to include this directory
+ARG LD_LIBRARY_PATH=/usr/local/lib
 ENV LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}
 
 # Clone and build OpenFHE-Python


### PR DESCRIPTION
Cause: Docker build failed