### PR TITLE
Correction of an error message

### DIFF
--- a/examples/pke/advanced-real-numbers-128.py
+++ b/examples/pke/advanced-real-numbers-128.py
@@ -383,7 +383,7 @@ def main():
         fast_rotation_demo1()
         fast_rotation_demo2()
     else:
-        print("This demo only runs for 128-bit CKKS.\nIf you want to test it please reinstall the OpenFHE C++ with the flag -DNATIVE_INT=128, then reinstall OpenFHE-Python.")
+        print("This demo only runs for 128-bit CKKS.\nIf you want to test it please reinstall the OpenFHE C++ with the flag -DNATIVE_SIZE=128, then reinstall OpenFHE-Python.")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Using the argument mentioned in the error message for cmake when building  openfhe-development for 128-bit CKKS yields the following message:
> Warning:
>Manually-specified variables were not used by the project: 
>NATIVE_INT

Looking at the current version of openfhe-development's CMakeLists.txt, the correct argument is -DNATIVE_SIZE.
https://github.com/openfheorg/openfhe-development/blob/7b8346f4eac27121543e36c17237b919e03ec058/CMakeLists.txt#L82