### PR TITLE
Corrections to CMakeLists.txt to find the installed .so

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,15 @@ pybind11_add_module(openfhe
                     )
 # The next line ensures that the installed openfhe module can find its shared library dependencies
 # in the 'lib/' subdirectory relative to itself without requiring LD_LIBRARY_PATH.
-target_link_options(openfhe PRIVATE "-Wl,-rpath=$ORIGIN/lib" "-Wl,--disable-new-dtags")
+### target_link_options(openfhe PRIVATE "-Wl,-rpath=$ORIGIN/lib" "-Wl,--disable-new-dtags")
+target_link_options(openfhe PRIVATE "-Wl,--enable-new-dtags" "-Wl,-rpath,\$ORIGIN/lib")
+
+# Also set target RPATH properties (survive install/copying)
+set_target_properties(openfhe PROPERTIES
+  BUILD_RPATH   "\$ORIGIN/lib"
+  INSTALL_RPATH "\$ORIGIN/lib"
+)
+
 
 ### Python installation 
 # Allow the user to specify the path to Python executable (if not provided, find it)


### PR DESCRIPTION
Fixing runtime error on Ubuntu 22:
Traceback (most recent call last):
  File "/home/git/openfhe-python/examples/pke/simple-integers.py", line 2, in <module>
    from openfhe import *
  File "/home/git/venv/lib/python3.10/site-packages/openfhe/__init__.py", line 1, in <module>
    from .openfhe import *
ImportError: libOPENFHEpke.so.1: cannot open shared object file: No such file or directory
