### PR TITLE
EvalSumRowsKeyGen() should return the native type instead of py::dict

### DIFF
--- a/src/lib/bindings.cpp
+++ b/src/lib/bindings.cpp
@@ -760,11 +760,7 @@ void bind_crypto_context(py::module &m) {
                 const PrivateKey<DCRTPoly> privateKey,
                 uint32_t rowSize,
                 uint32_t subringDim) {
-                auto m = self.EvalSumRowsKeyGen(privateKey, rowSize, subringDim);
-                py::dict d;
-                for (const auto& [k, v] : *m)
-                    d[py::int_(k)] = v;
-                return d;
+                return self.EvalSumRowsKeyGen(privateKey, rowSize, subringDim);
             },
             py::arg("privateKey"),
             py::arg("rowSize") = 0,
@@ -776,16 +772,13 @@ void bind_crypto_context(py::module &m) {
                 const PublicKey<DCRTPoly> publicKey,
                 uint32_t rowSize,
                 uint32_t subringDim) {
-                auto m = self.EvalSumRowsKeyGen(privateKey, publicKey, rowSize, subringDim);
-                py::dict d;
-                for (const auto& [k, v] : *m)
-                    d[py::int_(k)] = v;
-                return d;
+                return self.EvalSumRowsKeyGen(privateKey, publicKey, rowSize, subringDim);
             },
             py::arg("privateKey"),
             py::arg("publicKey"),
             py::arg("rowSize") = 0,
-            py::arg("subringDim") = 0)
+            py::arg("subringDim") = 0,
+            py::doc(cc_EvalSumRowsKeyGen_docs))
         // TODO (Oliveira, R.): Solve pointer handling bug when dealing with EvalKeyMap object for the next functions 
         .def("EvalSumColsKeyGen", &CryptoContextImpl<DCRTPoly>::EvalSumColsKeyGen,
             py::arg("privateKey"),


### PR DESCRIPTION
removed the code converting the return value type to py::dict.