### PR TITLE
New bindings

### DIFF
--- a/examples/pke/threshold-fhe.py
+++ b/examples/pke/threshold-fhe.py
@@ -18,6 +18,8 @@ def RunBGVrnsAdditive():
     parameters = CCParamsBGVRNS()
     parameters.SetPlaintextModulus(65537)
     parameters.SetMultiplicativeDepth(0)
+    parameters.SetKeySwitchTechnique(BV)
+    parameters.SetDigitSize(10)
 
     # NOISE_FLOODING_MULTIPARTY adds extra noise to the ciphertext before decrypting
     # and is most secure mode of threshold FHE for BFV and BGV.

--- a/examples/pke/threshold-fhe.py
+++ b/examples/pke/threshold-fhe.py
@@ -17,6 +17,7 @@ def main():
 def RunBGVrnsAdditive():
     parameters = CCParamsBGVRNS()
     parameters.SetPlaintextModulus(65537)
+    parameters.SetRingDim(32768)
 
     # NOISE_FLOODING_MULTIPARTY adds extra noise to the ciphertext before decrypting
     # and is most secure mode of threshold FHE for BFV and BGV.

--- a/examples/pke/threshold-fhe.py
+++ b/examples/pke/threshold-fhe.py
@@ -17,7 +17,7 @@ def main():
 def RunBGVrnsAdditive():
     parameters = CCParamsBGVRNS()
     parameters.SetPlaintextModulus(65537)
-    parameters.SetRingDim(32768)
+    parameters.SetMultiplicativeDepth(0)
 
     # NOISE_FLOODING_MULTIPARTY adds extra noise to the ciphertext before decrypting
     # and is most secure mode of threshold FHE for BFV and BGV.

--- a/src/include/docstrings/cryptocontext_docs.h
+++ b/src/include/docstrings/cryptocontext_docs.h
@@ -306,13 +306,24 @@ const char* cc_EvalAtIndexKeyGen_docs = R"pbdoc(
     :return: None
 )pbdoc";
 
-const char* cc_Encrypt_docs = R"doc(
+const char* cc_EncryptPubkey_docs = R"doc(
     Encrypt a plaintext using a given public key
 
     :param plaintext: plaintext
-    :type plaintext: Plaintext
+    :type plaintext: ConstPlaintext
     :param publicKey: public key
     :type publicKey: PublicKey
+    :return: ciphertext (or null on failure)
+    :rtype: Ciphertext
+)doc";
+
+const char* cc_EncryptPrivkey_docs = R"doc(
+    Encrypt a plaintext using a given private key
+
+    :param plaintext: plaintext
+    :type plaintext: ConstPlaintext
+    :param privateKey: private key
+    :type privateKey: PrivateKey
     :return: ciphertext (or null on failure)
     :rtype: Ciphertext
 )doc";

--- a/src/lib/bindings.cpp
+++ b/src/lib/bindings.cpp
@@ -613,7 +613,12 @@ void bind_crypto_context(py::module &m) {
             py::overload_cast<const PublicKey<DCRTPoly>&, ConstPlaintext&>(&CryptoContextImpl<DCRTPoly>::Encrypt, py::const_),
             py::arg("publicKey"),
             py::arg("plaintext"),
-            py::doc(cc_Encrypt_docs))
+            py::doc(cc_EncryptPubkey_docs))
+       .def("Encrypt",
+            py::overload_cast<const PrivateKey<DCRTPoly>&, ConstPlaintext&>(&CryptoContextImpl<DCRTPoly>::Encrypt, py::const_),
+            py::arg("privateKey"),
+            py::arg("plaintext"),
+            py::doc(cc_EncryptPrivkey_docs))
         .def("Decrypt",
             [](CryptoContext<DCRTPoly>& self, const PrivateKey<DCRTPoly> privKey, ConstCiphertext<DCRTPoly> ct) {
                 Plaintext result;


### PR DESCRIPTION
1. New binding for Encrypt() with private key
2. Set  multiplicativeDepth to 0 in examples/pke/threshold-fhe.py: RunBGVrnsAdditive() 